### PR TITLE
[update]: スキル解除キャンセラーの実装

### DIFF
--- a/src/main/java/net/lifecity/mc/skillmaster/skill/SeparatedSkill.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/SeparatedSkill.kt
@@ -14,8 +14,9 @@ abstract class SeparatedSkill(
     lore: List<String>,
     val activationTime: Int,
     interval: Int,
-    user: SkillUser?
-): Skill(name, weaponList, type, lore, interval, user = user) {
+    user: SkillUser?,
+    val canCancelRelieve: Boolean = true
+) : Skill(name, weaponList, type, lore, interval, user = user) {
 
     var activated = false
 

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/SeparatedSkill.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/SeparatedSkill.kt
@@ -15,7 +15,7 @@ abstract class SeparatedSkill(
     val activationTime: Int,
     interval: Int,
     user: SkillUser?,
-    val canCancelRelieve: Boolean = true
+    val canCancel: Boolean = true
 ) : Skill(name, weaponList, type, lore, interval, user = user) {
 
     var activated = false

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/Skill.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/Skill.kt
@@ -57,7 +57,9 @@ open class Skill(
     /**
      * スキルの状態を初期化します
      */
-    open fun init() { inInterval = false }
+    open fun init() {
+        inInterval = false
+    }
 
     /**
      * パーティクルを表示します

--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -192,7 +192,7 @@ class SkillUser(
             if (activatedSkill != null) {
                 // 発動中スキルが発動しようとしてるスキルと同一でない
                 // かつ発動中スキルが解除可能だったら
-                if (activatedSkill != skill && activatedSkill.canCancel) {
+                if (activatedSkill != skill || activatedSkill.canCancel) {
                     activatedSkill.deactivate()
                 }
             }

--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -77,11 +77,14 @@ class SkillUser(
      * 発動中のスキルの解除と、自身のベクトルを0にする
      */
     fun leftClick() {
-        // 発動中のスキルを解除
-        getActivatedSkill()?.deactivate()
+        getActivatedSkill()?.let {
+            if(it.canCancelRelieve) { //もしスキル解除キャンセル可能だったら
+                it.deactivate() // 発動中のスキルを解除
 
-        // プレイヤーのベクトルを0にする
-        player.velocity = Vector(0.0, player.velocity.y, 0.0)
+                // プレイヤーのベクトルを0にする
+                player.velocity = Vector(0.0, player.velocity.y, 0.0)
+            }
+        }
     }
 
     /**

--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -78,7 +78,7 @@ class SkillUser(
      */
     fun leftClick() {
         getActivatedSkill()?.let {
-            if(it.canCancelRelieve) { //もしスキル解除キャンセル可能だったら
+            if(it.canCancel) { //もしスキル解除可能だったら
                 it.deactivate() // 発動中のスキルを解除
 
                 // プレイヤーのベクトルを0にする
@@ -188,10 +188,13 @@ class SkillUser(
             // 現在の発動中スキルを取得
             val activatedSkill: SeparatedSkill? = getActivatedSkill()
 
-            // 発動中スキルが発動しようとしてるスキルと同一でなければスキル解除
+
             if (activatedSkill != null) {
-                if (activatedSkill != skill)
+                // 発動中スキルが発動しようとしてるスキルと同一でない
+                // かつ発動中スキルがキャンセル解除可能だったら
+                if (activatedSkill != skill && activatedSkill.canCancel) {
                     activatedSkill.deactivate()
+                }
             }
 
             // 発動中だったら追加入力

--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -191,7 +191,7 @@ class SkillUser(
 
             if (activatedSkill != null) {
                 // 発動中スキルが発動しようとしてるスキルと同一でない
-                // かつ発動中スキルがキャンセル解除可能だったら
+                // かつ発動中スキルが解除可能だったら
                 if (activatedSkill != skill && activatedSkill.canCancel) {
                     activatedSkill.deactivate()
                 }


### PR DESCRIPTION
## 具体的な実装方法
SeparatedSkillのコンストラクタに以下のようにプロパティを加え、SkillUserクラス内のleftCLickメソッドを以下のように変更し、スキル解除不可能なスキルを設定できるようにした。
```kotlin
abstract class SeparatedSkill(
    name: String,
    weaponList: List<Weapon>,
    type: SkillType,
    lore: List<String>,
    val activationTime: Int,
    interval: Int,
    user: SkillUser?,
    val canCancelRelieve: Boolean = true
) : Skill(name, weaponList, type, lore, interval, user = user) {
```

```kotlin
fun leftClick() {
        getActivatedSkill()?.let {
            if(it.canCancelRelieve) { //もしスキル解除キャンセル可能だったら
                it.deactivate() // 発動中のスキルを解除

                // プレイヤーのベクトルを0にする
                player.velocity = Vector(0.0, player.velocity.y, 0.0)
            }
        }
    }
```

## 関連するIssue
close #115 