### PR TITLE
Koryu25/add height limit

### DIFF
--- a/src/main/java/net/lifecity/mc/skillmaster/SkillMaster.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/SkillMaster.kt
@@ -35,7 +35,7 @@ class SkillMaster : JavaPlugin() {
         userList = SkillUserList()
         stageList = GameStageList()
 
-        val stage = GameStage("闘技場")
+        val stage = GameStage("闘技場", -25)
         stage.addField(
             TwoPoint(
                 stage,

--- a/src/main/java/net/lifecity/mc/skillmaster/game/Game.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/game/Game.kt
@@ -22,6 +22,7 @@ abstract class Game protected constructor(
     protected val gameTime: Int, //ゲームの時間(秒)
     protected val countDownTime: Int //ゲーム開始前のカウントダウンの時間(秒)
 ) {
+    private val HEIGHT_LIMIT = 30
     protected var countDownTimer = CountDownTimer()
     protected var gameTimer = GameTimer()
     protected var elapsedTime = 0 //経過時間
@@ -256,7 +257,7 @@ abstract class Game protected constructor(
                     val userY = user.player.location.y
 
                     val stage = getNowStage() ?: return
-                    if (userY >= stage.highestHeight + 30) {
+                    if (userY >= stage.highestHeight + HEIGHT_LIMIT) {
                         // 下方向に飛ばす
                         user.player.velocity.add(Vector(0.0, -2.75, 0.0))
                     }

--- a/src/main/java/net/lifecity/mc/skillmaster/game/Game.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/game/Game.kt
@@ -3,12 +3,14 @@ package net.lifecity.mc.skillmaster.game
 import com.github.syari.spigot.api.scheduler.runTaskTimer
 import net.lifecity.mc.skillmaster.SkillMaster
 import net.lifecity.mc.skillmaster.game.stage.FieldType
+import net.lifecity.mc.skillmaster.game.stage.GameStage
 import net.lifecity.mc.skillmaster.user.SkillUser
 import net.lifecity.mc.skillmaster.user.UserMode
 import org.bukkit.ChatColor
 import org.bukkit.GameMode
 import org.bukkit.Sound
 import org.bukkit.scheduler.BukkitRunnable
+import org.bukkit.util.Vector
 
 /**
  * ひとつのゲームを管理します
@@ -119,6 +121,17 @@ abstract class Game protected constructor(
      * @return 存在したらtrue
      */
     abstract fun hasTeam(team: GameTeam): Boolean
+
+    /**
+     * このゲームのステージを取得します
+     * @return ステージ
+     */
+    fun getNowStage(): GameStage? {
+        for (stage in SkillMaster.INSTANCE.stageList.list) {
+            if (stage.nowGame == this) return stage
+        }
+        return null
+    }
 
 
     /**
@@ -235,6 +248,19 @@ abstract class Game protected constructor(
                 sendTitleAll("${ChatColor.YELLOW}Start!!", "")
                 // 爆発音
                 playSoundAll(Sound.ENTITY_GENERIC_EXPLODE)
+            }
+
+            // ユーザーの高さ確認
+            for (team in teams) {
+                for (user in team.userArray) {
+                    val userY = user.player.location.y
+
+                    val stage = getNowStage() ?: return
+                    if (userY >= stage.highestHeight + 30) {
+                        // 下方向に飛ばす
+                        user.player.velocity.add(Vector(0.0, -2.75, 0.0))
+                    }
+                }
             }
 
             // ゲームの状態がゲーム中でなかったらタスクキャンセル

--- a/src/main/java/net/lifecity/mc/skillmaster/game/GameTeam.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/game/GameTeam.kt
@@ -9,7 +9,7 @@ import org.bukkit.GameMode
 import org.bukkit.Location
 import org.bukkit.Sound
 
-class GameTeam(private val name: String, private val color: ChatColor, private val userArray: Array<SkillUser>) {
+class GameTeam(private val name: String, private val color: ChatColor, val userArray: Array<SkillUser>) {
     /**
      * このチーム全員のゲームモードを変更します
      * @param mode このモードに変更します

--- a/src/main/java/net/lifecity/mc/skillmaster/game/stage/GameStage.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/game/stage/GameStage.kt
@@ -6,7 +6,7 @@ import net.lifecity.mc.skillmaster.game.Game
  * ゲームに使う場所を管理します
  * スポーンやギミックに使うLocationは継承先のフィールドとして実装してください
  */
-class GameStage(val name: String) {
+class GameStage(val name: String, val highestHeight: Int) {
     val fieldMap = mutableMapOf<FieldType, GameField>()
 
     var nowGame: Game? = null // 稼働中のゲーム


### PR DESCRIPTION
### 具体的な実装方法または変更点
ゲームクラスのゲームタイマーに条件分岐を追加しました。  
一秒ごとにプレイヤーの高さを確認して一定以上高ければ下に飛ばす処理です。

### 補足事項
N/A

### 関連するIssue
- close #96 