### PR TITLE
[新機能]: 直剣スキル「レイザースタブ」の実装

### DIFF
--- a/src/main/java/net/lifecity/mc/skillmaster/skill/SkillManager.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/SkillManager.kt
@@ -4,31 +4,28 @@ import net.lifecity.mc.skillmaster.skill.defenseskills.NormalDefense
 import net.lifecity.mc.skillmaster.skill.separatedskills.JumpAttackSlash
 import net.lifecity.mc.skillmaster.skill.separatedskills.LeafFlow
 import net.lifecity.mc.skillmaster.skill.separatedskills.Wall
-import net.lifecity.mc.skillmaster.skill.skills.HighJump
-import net.lifecity.mc.skillmaster.skill.skills.Kick
-import net.lifecity.mc.skillmaster.skill.skills.MoveFast
-import net.lifecity.mc.skillmaster.skill.skills.VectorAttack
+import net.lifecity.mc.skillmaster.skill.skills.*
 import net.lifecity.mc.skillmaster.user.SkillUser
 import net.lifecity.mc.skillmaster.weapon.Weapon
 import org.bukkit.inventory.ItemStack
 import org.bukkit.util.Vector
 
 class SkillManager(val user: SkillUser?) {
-    val skillList = mutableListOf<Skill>()
+    // スキルの登録
+    val skillList = listOf(
+        RazorStub(user),
+        LeafFlow(user),
+        JumpAttackSlash(user),
+        Wall(user),
+        MoveFast(user),
+        VectorAttack(user),
+        HighJump(user),
+        Kick(user),
+        NormalDefense(user),
+    )
 
     init {
         // スキルの登録
-        /*
-        skillList.add(LeafFlow(user))
-        skillList.add(JumpAttackSlash(user))
-        skillList.add(Wall(user))
-        skillList.add(MoveFast(user))
-        skillList.add(VectorAttack(user))
-        skillList.add(HighJump(user))
-        skillList.add(Kick(user))
-        skillList.add(NormalDefense(user))
-         */
-
         for ((id, skill) in skillList.withIndex()) {
             skill.id = id
         }

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
@@ -44,8 +44,14 @@ class RazorStub(user: SkillUser?) : Skill(
         val threshold = 1.0
         var target: T? = null
 
-        for (other in entities) {
+        for (other in entities) { //iterableリストの中を走査
+            //自分のベクトルと、対象のベクトルの差を計算 => 相手が向いている方向と自分が向いている方向が逆ならば最大, 同じならば最小
             val vec = other.location.toVector().subtract(entity.location.toVector())
+
+            // 自分のベクトルと、vecの外積の長さが1未満である => 自分のベクトルとvecがなす平行四辺形の面積が1未満、
+            // つまりここでもどの程度同じ方向を向いているか判定している。
+            // かつvecと自分のベクトルの内積が0以上 => 自分のベクトルがvecの向いている方向と同じ方向
+            // であるならば
             if (entity.location.direction.normalize().crossProduct(vec).lengthSquared() < threshold
                 && vec.normalize().dot(entity.location.direction.normalize()) >= 0) {
 

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
@@ -4,6 +4,8 @@ import net.lifecity.mc.skillmaster.skill.Skill
 import net.lifecity.mc.skillmaster.skill.SkillType
 import net.lifecity.mc.skillmaster.user.SkillUser
 import net.lifecity.mc.skillmaster.weapon.Weapon
+import org.bukkit.ChatColor
+import org.bukkit.entity.Entity
 import org.bukkit.entity.Player
 import org.bukkit.util.Vector
 
@@ -16,19 +18,43 @@ class RazorStub(user: SkillUser?) : Skill(
     user = user
 ) {
     override fun activate() {
-        if(user == null) return
+        if (user == null) return
 
         val player = this.user.player
-        val world = player.world
+        val target = getTargetEntity(player, player.getNearbyEntities(3.0,3.0,3.0))
 
-        val traceResult = world.rayTraceEntities(player.location, player.location.direction, 2.0)
-        traceResult?.let {
-            val target = it.hitEntity as? Player ?: return
-
-            player.sendMessage("レイザースタブ発動")
-            val vector = Vector(0.0, 2.5, 0.0)
-            target.velocity = vector
+        target?.let {
+            val targetPlayer = target as? Player ?: return
+            if (targetPlayer != player) {
+                user.sendActionBar("${ChatColor.DARK_AQUA} スキル『$name』発動")
+                player.sendMessage("レイザースタブ発動")
+                val vector = Vector(0.0, 1.5, 0.0)
+                targetPlayer.velocity = vector
+                super.deactivate()
+            }
         }
+    }
+
+    /**
+     * @param entity: 始点となるエンティティ
+     * @param entities: 探索対象のEntityのIterableリスト
+     * @return: 探索によって得られたEntity
+     */
+    private fun <T : Entity> getTargetEntity(entity: Entity, entities: Iterable<T>): T? {
+        val threshold = 1.0
+        var target: T? = null
+
+        for (other in entities) {
+            val vec = other.location.toVector().subtract(entity.location.toVector())
+            if (entity.location.direction.normalize().crossProduct(vec).lengthSquared() < threshold
+                && vec.normalize().dot(entity.location.direction.normalize()) >= 0) {
+
+                if(target == null || target.location.distanceSquared(entity.location) > other.location.distanceSquared(entity.location)) {
+                    target = other
+                }
+            }
+        }
+        return target
     }
 
 }

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
@@ -5,9 +5,12 @@ import net.lifecity.mc.skillmaster.skill.SkillType
 import net.lifecity.mc.skillmaster.user.SkillUser
 import net.lifecity.mc.skillmaster.weapon.Weapon
 import org.bukkit.ChatColor
+import org.bukkit.Location
+import org.bukkit.Particle
 import org.bukkit.entity.Entity
-import org.bukkit.entity.Player
 import org.bukkit.util.Vector
+import kotlin.math.cos
+import kotlin.math.sin
 
 class RazorStub(user: SkillUser?) : Skill(
     "レイザースタブ",
@@ -21,15 +24,15 @@ class RazorStub(user: SkillUser?) : Skill(
         if (user == null) return
 
         val player = this.user.player
-        val target = getTargetEntity(player, player.getNearbyEntities(3.0,3.0,3.0))
+        val target = getTargetEntity(player, player.getNearbyEntities(3.0, 3.0, 3.0))
 
         target?.let {
-            val targetPlayer = target as? Player ?: return
-            if (targetPlayer != player) {
+//            val targetPlayer = target as? Player ?: return
+            if (target != player) {
                 user.sendActionBar("${ChatColor.DARK_AQUA} スキル『$name』発動")
-                player.sendMessage("レイザースタブ発動")
-                val vector = Vector(0.0, 1.5, 0.0)
-                targetPlayer.velocity = vector
+                drawParticle(target)
+                val vector = Vector(0.0, 1.0, 0.0)
+                target.velocity = vector
                 super.deactivate()
             }
         }
@@ -53,14 +56,87 @@ class RazorStub(user: SkillUser?) : Skill(
             // かつvecと自分のベクトルの内積が0以上 => 自分のベクトルがvecの向いている方向と同じ方向
             // であるならば
             if (entity.location.direction.normalize().crossProduct(vec).lengthSquared() < threshold
-                && vec.normalize().dot(entity.location.direction.normalize()) >= 0) {
+                && vec.normalize().dot(entity.location.direction.normalize()) >= 0
+            ) {
 
-                if(target == null || target.location.distanceSquared(entity.location) > other.location.distanceSquared(entity.location)) {
+                if (target == null || target.location.distanceSquared(entity.location) > other.location.distanceSquared(
+                        entity.location
+                    )
+                ) {
                     target = other
                 }
             }
         }
         return target
     }
+
+    private fun drawParticle(target: Entity) {
+        if (user == null) return
+
+        val loc =
+            Location(target.world, target.location.x, target.location.y , target.location.z)
+
+        drawCircle(loc, Particle.SPELL_WITCH, 1.0, 30, 0.0, 0.0, 0.0)
+
+    }
+
+    private fun drawCircle(
+        origin: Location,
+        particle: Particle,
+        radius: Double,
+        points: Int,
+        rotX: Double,
+        rotY: Double,
+        rotZ: Double
+    ) {
+        for (i in 0 until points) {
+            val t = i * 2 * Math.PI / points
+            val point = Vector(radius * cos(t), 0.0, radius * sin(t))
+            rotX(point, rotX)
+            rotY(point, rotY)
+            rotZ(point, rotZ)
+            origin.add(point)
+            // spawn something at origin
+            origin.world.spawnParticle(particle, origin, 10, null)
+            origin.subtract(point)
+        }
+    }
+
+    /**
+     * 与えたVectorをX軸回りでtだけ回転させる
+     *
+     * @param point: 回転させたいVector
+     * @param t:     角度
+     */
+    private fun rotX(point: Vector, t: Double) {
+        val y = point.y
+        point.y = y * cos(t) - point.z * sin(t)
+        point.z = y * sin(t) + point.z * cos(t)
+    }
+
+    /**
+     * 与えたVectorをY軸回りでtだけ回転させる
+     *
+     * @param point: 回転させたいVector
+     * @param t:     角度
+     */
+    private fun rotY(point: Vector, t: Double) {
+        val z = point.z
+        point.z = z * cos(t) - point.x * sin(t)
+        point.x = z * sin(t) + point.x * cos(t)
+    }
+
+    /**
+     * 与えたVectorをZ軸回りでtだけ回転させる
+     *
+     * @param point: 回転させたいVector
+     * @param t:     角度
+     */
+    private fun rotZ(point: Vector, t: Double) {
+        val x = point.x
+        point.x = x * cos(t) - point.y * sin(t)
+        point.y = x * sin(t) + point.y * cos(t)
+    }
+
 
 }

--- a/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/skill/skills/RazorStub.kt
@@ -1,0 +1,34 @@
+package net.lifecity.mc.skillmaster.skill.skills
+
+import net.lifecity.mc.skillmaster.skill.Skill
+import net.lifecity.mc.skillmaster.skill.SkillType
+import net.lifecity.mc.skillmaster.user.SkillUser
+import net.lifecity.mc.skillmaster.weapon.Weapon
+import org.bukkit.entity.Player
+import org.bukkit.util.Vector
+
+class RazorStub(user: SkillUser?) : Skill(
+    "レイザースタブ",
+    listOf(Weapon.STRAIGHT_SWORD),
+    SkillType.ATTACK,
+    listOf("剣に闇をまとわせて斜め下から切り上げる"),
+    0,
+    user = user
+) {
+    override fun activate() {
+        if(user == null) return
+
+        val player = this.user.player
+        val world = player.world
+
+        val traceResult = world.rayTraceEntities(player.location, player.location.direction, 2.0)
+        traceResult?.let {
+            val target = it.hitEntity as? Player ?: return
+
+            player.sendMessage("レイザースタブ発動")
+            val vector = Vector(0.0, 2.5, 0.0)
+            target.velocity = vector
+        }
+    }
+
+}


### PR DESCRIPTION
### 具体的な実装方法または変更点
getTargetEntityメソッドを実装して、プレイヤーの目の前にいるエンティティを真上に切り上げる処理を実装した。
具体的なスキル内容は[こちら](https://github.com/eryuLab/KoryuServerDocument/blob/main/%E6%B1%BA%E5%AE%9A%E4%BA%8B%E9%A0%85/%E3%82%B9%E3%82%AD%E3%83%AB/%E7%9B%B4%E5%89%A3%E3%82%B9%E3%82%AD%E3%83%AB.md)を参照

### 補足事項
N / A

### 関連するIssue
- close #158 