### PR TITLE
[品質向上]: スキルセットにスキルがない時その番号をとばす処理

### DIFF
--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -141,6 +141,13 @@ class SkillUser(
 
         // シフトが押されているときスキルセット番号変更
         if (player.isSneaking) {
+            // スキルが一定数以上格納されているか確認
+            val size = card.skillSet.containedSize()
+            if (size == 0 || size == 1) {
+                player.sendMessage("セットされているスキルの数が少ないため、変更できません")
+                return
+            }
+
             // セット番号の変更
             card.index++
 

--- a/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
@@ -1,6 +1,7 @@
 package net.lifecity.mc.skillmaster.user.skillset
 
 import net.lifecity.mc.skillmaster.skill.Skill
+import org.bukkit.Bukkit
 
 data class SkillCard(
     val button: SkillButton,
@@ -8,7 +9,17 @@ data class SkillCard(
 ) {
     var index: Int = 0
         set(value) {
+            val size = skillSet.containedSize()
+            if (size == 0 || size == 1)
+                return
+
             field = if (value >= skillSet.keyList.size) 0 else value
+
+            for (i in value..value + 2) {
+                if (now() == null) {
+                    field = if (i >= skillSet.keyList.size) 0 else i
+                }
+            }
         }
 
     fun now(): Skill? {

--- a/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillSet.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillSet.kt
@@ -8,6 +8,19 @@ data class SkillSet(
         SkillKey(button, 2, null)
     )
 ) {
+
+    /**
+     * セットされているスキルの数を取得します
+     */
+    fun containedSize(): Int {
+        var size = 0
+        for (key in keyList) {
+            if (key.skill != null)
+                size++
+        }
+        return size
+    }
+
     /**
      * セットされているスキルをリセットします
      */


### PR DESCRIPTION
### 具体的な実装方法または変更点
- スキルセット番号が変わるときにスキルの数を確認した
- 変えた番号にスキルがなければその番号を飛ばした

### 補足事項
補足事項を記載

### 関連するIssue
- close #97 