### PR TITLE
[バグ]: スキルセット番号が変わらない

### DIFF
--- a/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/SkillUser.kt
@@ -141,25 +141,30 @@ class SkillUser(
 
         // シフトが押されているときスキルセット番号変更
         if (player.isSneaking) {
-            // スキルが一定数以上格納されているか確認
             val size = card.skillSet.containedSize()
-            if (size == 0 || size == 1) {
-                player.sendMessage("セットされているスキルの数が少ないため、変更できません")
+            // スキルセットが0のとき変更なし
+            if (size == 0) {
+                player.sendMessage("セットされているスキルがありません")
                 return
             }
+            // スキルセットが1のとき
+            if (size == 1) {
+                // 現在のスキルがあるとき変更なし
+                if (card.now() != null) {
+                    player.sendMessage("セットされているスキルが少ないため変更できません")
+                    return
+                }
+            }
+            // 現在のスキルがないのとき変更
+            // スキルセットが2以上のとき次のスキルがあるまで変更
 
             // セット番号の変更
             card.index++
-
             // SE再生
             player.location.playSound(Sound.ENTITY_EXPERIENCE_BOTTLE_THROW)
-
             // ログ出力
-            val skill: Skill? = card.now()
-            if (skill == null)
-                player.sendMessage("${card.button.jp}[${card.index}]はスキルがセットされていません")
-            else
-                player.sendMessage("${card.button.jp}[${card.index}]を「${skill.name}」に変更しました")
+            val skill: Skill = card.now()!!
+            player.sendMessage("${card.button.jp}[${card.index}]を「${skill.name}」に変更しました")
         }
         else
             skillInput(card.now(), weapon)

--- a/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
@@ -14,7 +14,7 @@ data class SkillCard(
 
             // 番号変更後、スキルが存在したらbreak
             val size = skillSet.keyList.size
-            var index = value
+            var index = if (value >= size) 0 else value
             for (i in 0 until size) {
                 if (skillSet.keyList[index].skill != null) {
                     field = index

--- a/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
@@ -9,16 +9,20 @@ data class SkillCard(
 ) {
     var index: Int = 0
         set(value) {
-            val size = skillSet.containedSize()
-            if (size == 0 || size == 1)
+            if (skillSet.containedSize() == 0)
                 return
 
-            field = if (value >= skillSet.keyList.size) 0 else value
-
-            for (i in value..value + 2) {
-                if (now() == null) {
-                    field = if (i >= skillSet.keyList.size) 0 else i
+            // 番号変更後、スキルが存在したらbreak
+            val size = skillSet.keyList.size
+            var index = value
+            for (i in 0 until size) {
+                if (skillSet.keyList[index].skill != null) {
+                    field = index
+                    return
                 }
+                index++
+                if (index >= size)
+                    index = 0
             }
         }
 

--- a/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
+++ b/src/main/java/net/lifecity/mc/skillmaster/user/skillset/SkillCard.kt
@@ -15,7 +15,7 @@ data class SkillCard(
             // 番号変更後、スキルが存在したらbreak
             val size = skillSet.keyList.size
             var index = if (value >= size) 0 else value
-            for (i in 0 until size) {
+            repeat (size) {
                 if (skillSet.keyList[index].skill != null) {
                     field = index
                     return


### PR DESCRIPTION
### 具体的な実装方法または変更点
コードに汎用性がなかったため一から考え直した。  
条件分岐を繰り返した。

### 補足事項
N/A

### 関連するIssue
- close #224 